### PR TITLE
Update to newer COSA snapshot

### DIFF
--- a/build-podman-machine-os-disks.sh
+++ b/build-podman-machine-os-disks.sh
@@ -70,12 +70,12 @@ main() {
 
     # Freeze on specific version for now to increase stability.
     #gitreporef="main"
-    gitreporef="74395f97327e0927a82707ca6f59f93b169c4286"
+    gitreporef="3ab61dd19484055a89681698fbdbc0ea1f9d9c62"
     gitrepotld="https://raw.githubusercontent.com/coreos/coreos-assembler/${gitreporef}/"
     pushd ./tmp
     curl -LO --fail "${gitrepotld}/src/runvm-osbuild"
     chmod +x runvm-osbuild
-    for manifest in "coreos.osbuild.${ARCH}.mpp.yaml" platform.{applehv,hyperv,qemu,gcp}.ipp.yaml; do
+    for manifest in "coreos.osbuild.${ARCH}.mpp.yaml" platform.{applehv,hyperv,metal,qemu,gcp}.ipp.yaml; do
         curl -LO --fail "${gitrepotld}/src/osbuild-manifests/${manifest}"
     done
     popd


### PR DESCRIPTION
This includes using the new coreos.platforms stage and also the break out of metal manifests into their own file.